### PR TITLE
Edits to documentation to address points of confusion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,6 @@ encourage you to sign up for our `User Mailing List
 on releases, answer questions, and benefit from other users'
 questions.
 
-
-HoloPy is based upon work supported by the National Science Foundation
-under grant numbers CBET-0747625, DMR-0820484, DMR-1306410, and
-DMR-1420570.
+HoloPy is based upon work supported by the National Science Foundation under
+grant numbers CBET-0747625, DMR-0820484, DMR-1306410, DMR-1420570, and
+DMR-2011754.

--- a/docs/source/credits.rst
+++ b/docs/source/credits.rst
@@ -13,6 +13,8 @@ The following references describe applications of HoloPy and technical advances.
 If you use HoloPy, we ask that you cite the articles that are relevant to your
 application.
 
+.. [Martin2022] Martin, Caroline, Lauren E. Altman, Siddharth Rawat, Anna Wang, David G. Grier, and Vinothan N. Manoharan. “In-Line Holographic Microscopy with Model-Based Analysis.” Nature Reviews Methods Primers 2, no. 1 (October 20, 2022): 1–17. doi:10.1038/s43586-022-00165-z.
+
 .. [Martin2021] Martin, Caroline, Brian Leahy, and Vinothan N. Manoharan. “Improving Holographic Particle Characterization by Modeling Spherical Aberration.” Optics Express 29, no. 12 (June 7, 2021): 18212–23. doi:10.1364/OE.424043.
 
 .. [Leahy2020] Leahy, Brian, Ronald Alexander, Caroline Martin, Solomon Barkley, and Vinothan N. Manoharan.  “Large depth-of-field tracking of colloidal spheres in holographic microscopy by modeling the objective lens.” Optics Express 28, no. 2 (2020): 1061-1075. doi:10.1364/OE.382159
@@ -68,8 +70,8 @@ For an introduction to Bayesian analysis of experimental data, we recommend
 .. [Gregory2010] P\. Gregory, *Bayesian Logical Data Analysis for the Physical Sciences*, Cambridge University Press (2010)
 
 The package includes code from several sources. We thank Daniel Mackowski for
-allowing us to include his T-Matrix code, which computes scattering from
-clusters of spheres: SCSMFO1B_.
+allowing us to include his multisphere superposition code, which computes
+scattering from clusters of spheres: SCSMFO1B_.
 
 .. _SCSMFO1B: ftp://ftp.eng.auburn.edu/pub/dmckwski/scatcodes/index.html
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,7 @@ University <http://manoharan.seas.harvard.edu/holopy>`_. If you use HoloPy,
 you may wish to cite one or more of the sources listed in
 :ref:`credits`. We also encourage you to sign up for our `User Mailing
 List <https://groups.google.com/d/forum/holopy-users>`_ or join us on `GitHub
-<https://github.com/manoharan-lab/holopy>`_ to keep up to date on releases, 
+<https://github.com/manoharan-lab/holopy>`_ to keep up to date on releases,
 answer questions, and benefit from other users' questions.
 
 .. toctree::
@@ -36,6 +36,6 @@ answer questions, and benefit from other users' questions.
    reference/holopy
    credits
 
-HoloPy is based upon work supported by the National Science Foundation
-under grant numbers CBET-0747625, DMR-0820484, DMR-1306410, and
-DMR-1420570. 
+HoloPy is based upon work supported by the National Science Foundation under
+grant numbers CBET-0747625, DMR-0820484, DMR-1306410, DMR-1420570, and
+DMR-2011754.

--- a/docs/source/tutorial/calc_tutorial.rst
+++ b/docs/source/tutorial/calc_tutorial.rst
@@ -44,11 +44,12 @@ The next line describes the *scatterer* we would like to model:
 
     sphere = Sphere(n=1.59, r=0.5, center=(4, 4, 5))
 
-Scatterers are described in HoloPy by a :class:`.Scatterer` object. Here, we use a :class:`.Sphere` as the scatterer object. A :class:`.Scatterer` object
+Scatterers are described in HoloPy by a :class:`.Scatterer` object. Here, we use
+a :class:`.Sphere` as the scatterer object. A :class:`.Scatterer` object
 contains information about the geometry (position, size, shape) and optical
 properties (refractive index) of the object that is scattering light. We've
-defined a spherical scatterer with radius 0.5 microns and index of refraction
-1.59. This refractive index is approximately that of polystyrene.
+defined a spherical scatterer with radius 0.5 micrometers and index of
+refraction 1.59. This refractive index is approximately that of polystyrene.
 
 Next, we need to describe the *experimental setup*, including how we are
 illuminating our sphere, and how that light will be detected:
@@ -66,13 +67,16 @@ the x-direction to illuminate a sphere immersed in water (refractive index =
 about how the wavelength and polarization are specified.
 
 The scattered light will be collected at a detector, which is frequently a
-digital camera mounted onto a microscope.  We defined our detector as a 100 x
-100 pixel array, with each square pixel of side length .1 microns.  The
+digital camera mounted onto a microscope. We defined our detector as a 100 x 100
+pixel array, with each square pixel of side length 0.1 micrometers. The
 ``shape`` argument tells HoloPy how many pixels are in the detector and affects
-computation time. The ``spacing`` argument tells HoloPy how far apart each
-pixel is. Both parameters affect the absolute size of the detector.
+computation time. The ``spacing`` argument tells HoloPy how far apart each pixel
+is. Both parameters affect the absolute size of the detector.
 
-Finally, we need to specify the *scattering theory* which knows how to calculate the hologram from the experimental setup and the scatterer. By setting ``theory='auto'``, we let HoloPy automatically select a theory. If no theory is specified, HoloPy will automatically select a theory as well.
+Finally, we need to specify the *scattering theory* which knows how to calculate
+the hologram from the experimental setup and the scatterer. By setting
+``theory='auto'``, we let HoloPy automatically select a theory. If no theory is
+specified, HoloPy will automatically select a theory as well.
 
 After getting everything ready, the actual scattering calculation is straightforward:
 
@@ -217,10 +221,17 @@ sphere objects and passing a longer list of spheres to the
 Non-spherical Objects
 ---------------------
 
-To define a non-spherical scatterer, use :class:`.Spheroid` or :class:`.Cylinder` objects. These axisymmetric scatterers are defined by two dimensions, and can describe scatterers that are elongated or squashed along one direction.
-By default, these objects are aligned with the z-axis, but they can be rotated into any orientation by passing a set of Euler angles to the ``rotation`` argument when defining the scatterer. See :ref:`rotations` for information on how these angles are defined.
-As an example, here is a hologram produced by a cylinder aligned with the vertical axis (``x-axis`` according to the HoloPy :ref:`coordinate_system`).
-Note that the hologram image is elongated in the horizontal direction since the sides of the cylinder scatter light more than the ends.
+To define a non-spherical scatterer, use :class:`.Spheroid` or
+:class:`.Cylinder` objects. These axisymmetric scatterers are defined by two
+dimensions, and can describe scatterers that are elongated or squashed along one
+direction. By default, these objects are aligned with the z-axis, but they can
+be rotated into any orientation by passing a set of Euler angles to the
+``rotation`` argument when defining the scatterer. See :ref:`rotations` for
+information on how these angles are defined. As an example, here is a hologram
+produced by a cylinder aligned with the vertical axis (``x-axis`` according to
+the HoloPy :ref:`coordinate_system`). Note that the hologram image is elongated
+in the horizontal direction since the sides of the cylinder scatter light more
+than the ends.
 
 ..  testcode::
 
@@ -300,10 +311,10 @@ with the optical train in varying degrees of complexity. HoloPy has
 scattering theories that describe scattering from individual spheres,
 layered spheres, clusters of spheres, spheroids, cylinders, and
 arbitrary objects. Some of these scattering theories can take parameters
-to modify how the theory performs the calculation (by, *e.g.*, making
-certain approximations or specifying properties of the optical train).
-For a more thorough description of these scattering theories and how
-HoloPy chooses default scattering theories, see the user guide,
+to modify how the theory performs the calculation (by, for example,
+making certain approximations or specifying properties of the optical
+train). For a more thorough description of these scattering theories and
+how HoloPy chooses default scattering theories, see the user guide,
 :ref:`theories_user`.
 
 

--- a/docs/source/tutorial/load_tutorial.rst
+++ b/docs/source/tutorial/load_tutorial.rst
@@ -158,7 +158,7 @@ same image::
 
     hp.save('outfilename', holo)
 
-saves your processed image to a compact HDF5 file. In fact, you can use :func:`.save`
+saves your processed image to a compact HDF5 file. In fact, you can use :func:`~.io.save`
 on any holopy object. To reload your same hologram with metadata you would write::
 
     holo = hp.load('outfilename')
@@ -169,4 +169,4 @@ If you would like to save your hologram to an image format for easy visualizatio
 
 Additional options of :func:`.save_image` allow you to control how image intensity is scaled.
 Although HoloPy stores metadata when writing to .tif image files, you should save
-holograms in HDF5 format using :func:`.save` to avoid rounding.
+holograms in HDF5 format using :func:`~.io.save` to avoid rounding.

--- a/docs/source/users/scatterers.rst
+++ b/docs/source/users/scatterers.rst
@@ -104,8 +104,11 @@ Component scatterer handling
       New scatterer rotated about its center according to
       :ref:`HoloPy rotation conventions<rotations>`
 
-There are two specific composite scatterer classes for working with collections of
-spheres that have additional functionality:
+Although you can add any scatterer to a :class:`.Scatterers` object, HoloPy
+cannot yet calculate holograms from a :class:`.Scatterers` object consisting of
+non-spherical particles. However, you can calculate holograms of collections of
+spheres using the two specific composite scatterer classes below, which have
+additional functionality:
 
 :class:`.Spheres`
     A collection of spherical scatterers, with the following properties:

--- a/docs/source/users/theories.rst
+++ b/docs/source/users/theories.rst
@@ -70,13 +70,15 @@ Lens-Free Scattering Theories
     * Can handle :class:`.Sphere` objects, :class:`.LayeredSphere` objects, or
       :class:`.Spheres` through superposition.
     * Computes scattered fields using Mie theory.
+    * By default, calculates the radial (near-field) component of
+      scattered electric fields, which is nonradiative.
 - :class:`.Multisphere`
     * Can handle :class:`.Spheres` objects.
     * Cannot handle :class:`.Spheres` objects composed of layered
       spheres.
-    * Computes scattered fields through a T-matrix-based solution of
-      scattering, accounting for multiple scattering between spheres to
-      find a (numerically) exact solution.
+    * Computes scattered fields through a superposition solution of
+      scattering, accounting for near-field and far-field coupling
+      (multiple scattering) to find a (numerically) exact solution.
 - :class:`.Tmatrix`
     * Can handle :class:`.Sphere`, :class:`.Cylinder`, or :class:`.Spheroid`
       objects.
@@ -123,10 +125,9 @@ HoloPy chooses a default scattering theory based off the scatterer type,
 currently determined by the function
 :func:`.determine_default_theory_for`. If you're not satisfied with
 HoloPy's default scattering theory selection, you should choose the
-scattering theory based off of (1) the scatterer that you are modeling,
+scattering theory based on (1) the scatterer that you are modeling,
 and (2) whether you want to describe the effect of the lens on the
 recorded hologram in detail.
-
 
 An Individual Sphere
 ~~~~~~~~~~~~~~~~~~~~
@@ -137,34 +138,57 @@ solution to Maxwell's equations for the scattered field from a spherical
 particle, originally derived by Gustav Mie and (independently) by Ludvig
 Lorenz in the early 1900s.
 
-Multiple Spheres
-~~~~~~~~~~~~~~~~
-
-A scatterer composed of multiple spheres can exhibit multiple scattering and
-coupling of the near-fields of neighbouring particles. Mie theory doesn't
-include these effects, so :class:`.Spheres` objects are by default calculated
-using the :class:`.Multisphere` theory, which accounts for multiple
-scattering by using the SCSMFO package from `Daniel Mackowski
-<http://www.eng.auburn.edu/~dmckwski/>`_.  This calculation uses
-T-matrix methods to give the exact solution to Maxwell's equation for
-the scattering from an arbitrary arrangement of non-overlapping spheres.
-
-Sometimes you might want to calculate scattering from multiple spheres
-using Mie theory if you are worried about computation time or if your
-spheres are widely separated (such that optical coupling between the
-spheres is negligible) You can specify Mie theory manually when calling
-the :func:`.calc_holo` function, as the following code snippet shows:
-
+By default, HoloPy computes the radial components of the scattered
+fields, which can affect the hologram if the detector is very close to
+the detector. But if you have a spherical particle that is far (more
+than a few wavelengths) from the detector, you can save time and avoid
+numerical issues by telling HoloPy to use the far-field Mie solutions,
+as in this example:
 
 ..  testcode::
 
     import holopy as hp
+    from holopy.scattering import Sphere, Mie, calc_holo
+
+    sphere = Sphere(center=(100, 100, 1500), n = 1.59, r = 7.5)
+
+    medium_index = 1.33
+    illum_wavelen = 0.465
+    illum_polarization = (1, 0)
+    detector = hp.detector_grid(shape=200, spacing=1.0)
+
+    far_field_mie = Mie(compute_escat_radial=False, full_radial_dependence=False)
+
+    holo = calc_holo(detector, sphere, medium_index, illum_wavelen,
+                     illum_polarization, theory=far_field_mie)
+
+
+Multiple Spheres
+~~~~~~~~~~~~~~~~
+
+A scatterer composed of multiple spheres can exhibit multiple scattering
+and coupling of the near-fields of neighboring particles. Mie theory
+doesn't include these effects, so :class:`.Spheres` objects are by
+default calculated using the :class:`.Multisphere` theory, which
+accounts for near- and far-field coupling of the scattered fields
+through the SCSMFO package from `Daniel Mackowski
+<http://www.eng.auburn.edu/~dmckwski/>`_. This calculation relies on the
+exact solution to Maxwell's equation for the scattering from an
+arbitrary arrangement of non-overlapping spheres.
+
+If you want to reduce computation time, or your spheres are widely
+separated (such that optical coupling between the spheres is
+negligible), you can approximate the scattering from a cluster of
+spheres by adding the far fields. To perform such a calculation, which
+does not account for multiple scattering, you can specify Mie theory
+manually when calling the :func:`.calc_holo` function, as the following
+code snippet shows:
+
+
+..  testcode::
+
     from holopy.core.io import get_example_data_path
-    from holopy.scattering import (
-        Sphere,
-        Spheres,
-        Mie,
-        calc_holo)
+    from holopy.scattering import Spheres
 
     s1 = Sphere(center=(5, 5, 5), n = 1.59, r = .5)
     s2 = Sphere(center=(4, 4, 5), n = 1.59, r = .5)
@@ -188,7 +212,7 @@ the :func:`.calc_holo` function, as the following code snippet shows:
 
 Note that the multisphere theory does not work with collections of
 multi-layered spheres; in this case HoloPy defaults to using Mie theory
-with superposition.
+with superposition (that is, neglecting multiple scattering).
 
 Non-spherical particles
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -218,25 +242,27 @@ details.
 Including the effect of the lens
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Most of the scattering theories in HoloPy treat the fields on the detector as
-a (magnified) image of the fields at the focal plane. While these theories
-usually provide a good description of holograms of particles far above the
-focus, when the particle is near near the focus subtle optical effects can
-cause deviations between the recorded hologram and theories which do not
-specifically describe the effects of the lens. To deal with this, HoloPy
-currently offers two scattering theories which describe the effects of a
-perfect lens on the recorded hologram. Both of these scattering theories
-need information about the lens to make predictions, specifically the
-acceptance angle of the lens. The acceptance angle :math:`\beta` is
-related to the numerical aperture or NA of the lens by :math:`\beta =
-\arcsin(NA / n_f)`, where :math:`n_f` is the refractive of the immersion
-fluid. For more details on the effect of the lens on the recorded
-hologram, see [Leahy2020]_ and [Martin2021]_.
+Most of the scattering theories in HoloPy treat the fields on the
+detector as a (magnified) image of the fields at the focal plane. While
+these theories usually provide a good description of holograms of
+particles far above the focus, when the particle is near the focus
+subtle optical effects can cause deviations between the recorded
+hologram and theories which do not specifically describe the effects of
+the lens. To deal with this, HoloPy currently offers two scattering
+theories which describe the effects of a perfect lens on the recorded
+hologram. Both of these scattering theories need information about the
+lens to make predictions, specifically the acceptance angle of the lens.
+The acceptance angle :math:`\beta` is related to the numerical aperture
+or NA of the lens by :math:`\beta = \arcsin(\text{NA} / n_f)`, where
+:math:`n_f` is the refractive index of the immersion fluid. For more
+details on the effect of the lens on the recorded hologram, see
+[Leahy2020]_ and [Martin2021]_.
 
-The :class:`.Lens` theory allows HoloPy to include the effects of a perfect
-objective lens with any scattering theory. The Lens theory works by wrapping a
-normal scattering theory. For instance, to calculate the image of a sphere in
-an objective lens with an acceptance angle of 1.0, do
+The :class:`.Lens` theory allows HoloPy to include the effects of a
+perfect objective lens with any scattering theory. The Lens theory works
+by wrapping a normal scattering theory. For instance, to calculate the
+image of a sphere in an objective lens with an acceptance angle of 1.0,
+do
 
 ..  testcode::
 
@@ -282,11 +308,12 @@ other scattering theory:
         lens_angle=lens_angle)
 
 
-My Scattering theory isn't here?!?!
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Why isn't my scattering theory here?!
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Add your own scattering theory to HoloPy! See :ref:`scat_theory` for
-details. If you think your new scattering theory may be useful for other
-users, please consider submitting a `pull request
+If you don't see your favorite scattering theory, you can add it to
+HoloPy! See :ref:`scat_theory` for details. If you think your new
+scattering theory may be useful for other users, please consider
+submitting a `pull request
 <https://github.com/manoharan-lab/holopy/pulls>`_.
 


### PR DESCRIPTION
The documentation now clarifies that holograms cannot be computed from a generic `Scatterers` object, and there is now a new section detailing how to calculate the far-field Mie solution (which is useful when the scatterer is far from the detector).  Also made some updates and minor edits.